### PR TITLE
Updates

### DIFF
--- a/PrismaDB-QueryAST/DDL/ColumnDefinition.cs
+++ b/PrismaDB-QueryAST/DDL/ColumnDefinition.cs
@@ -5,67 +5,6 @@ using System.Linq;
 
 namespace PrismaDB.QueryAST.DDL
 {
-    public enum SqlDataType
-    {
-        MSSQL_INT = 0,
-        MSSQL_TINYINT = 1,
-        MSSQL_SMALLINT = 2,
-        MSSQL_BIGINT = 3,
-        MSSQL_FLOAT = 4,
-
-        MSSQL_DATE = 100,
-        MSSQL_DATETIME = 101,
-
-        MSSQL_CHAR = 200,
-        MSSQL_VARCHAR = 201,
-        MSSQL_TEXT = 202,
-        MSSQL_NCHAR = 203,
-        MSSQL_NVARCHAR = 204,
-        MSSQL_NTEXT = 205,
-
-        MSSQL_BINARY = 300,
-        MSSQL_VARBINARY = 301,
-
-        MSSQL_UNIQUEIDENTIFIER = 400,
-
-
-        MySQL_INT = 1000,
-        MySQL_TINYINT = 1001,
-        MySQL_SMALLINT = 1002,
-        MySQL_BIGINT = 1003,
-        MySQL_DOUBLE = 1004,
-
-        MySQL_DATE = 1100,
-        MySQL_DATETIME = 1101,
-        MySQL_TIMESTAMP = 1102,
-
-        MySQL_CHAR = 1200,
-        MySQL_VARCHAR = 1201,
-        MySQL_TEXT = 1202,
-
-        MySQL_BINARY = 1300,
-        MySQL_VARBINARY = 1301,
-        MySQL_BLOB = 1302,
-
-        MySQL_ENUM = 1400,
-
-
-        Postgres_INT4 = 2000,
-        Postgres_INT2 = 2001,
-        Postgres_INT8 = 2002,
-        Postgres_FLOAT4 = 2003,
-        Postgres_FLOAT8 = 2004,
-
-        Postgres_DATE = 2100,
-        Postgres_TIMESTAMP = 2101,
-
-        Postgres_CHAR = 2200,
-        Postgres_VARCHAR = 2201,
-        Postgres_TEXT = 2202,
-
-        Postgres_BYTEA = 2300
-    }
-
     [Flags]
     public enum ColumnEncryptionFlags
     {

--- a/PrismaDB-QueryAST/DDL/DataTypes.cs
+++ b/PrismaDB-QueryAST/DDL/DataTypes.cs
@@ -138,9 +138,6 @@ namespace PrismaDB.QueryAST.DDL
 
         public static SqlDataType GetSqlDataType(Type type, TargetDatabase target)
         {
-            if (type == typeof(byte[]))
-                return GetSqlVarBinaryDataType(target);
-
             switch (Type.GetTypeCode(type))
             {
                 case TypeCode.Int32:
@@ -159,9 +156,14 @@ namespace PrismaDB.QueryAST.DDL
                     return GetSqlVarCharDataType(target);
                 case TypeCode.DateTime:
                     return GetSqlDateTimeDataType(target);
+                case TypeCode.Object:
+                    if (type == typeof(byte[]))
+                        return GetSqlVarBinaryDataType(target);
+                    else
+                        throw new ArgumentOutOfRangeException();
+                default:
+                    throw new ArgumentOutOfRangeException();
             }
-
-            throw new ArgumentOutOfRangeException();
         }
 
         public static SqlDataType GetSqlIntDataType(TargetDatabase target)

--- a/PrismaDB-QueryAST/DDL/DataTypes.cs
+++ b/PrismaDB-QueryAST/DDL/DataTypes.cs
@@ -1,0 +1,343 @@
+﻿using System;
+
+namespace PrismaDB.QueryAST.DDL
+{
+    public enum SqlDataType
+    {
+        MSSQL_INT = 0,
+        MSSQL_TINYINT = 1,
+        MSSQL_SMALLINT = 2,
+        MSSQL_BIGINT = 3,
+        MSSQL_FLOAT = 4,
+        MSSQL_DECIMAL = 5,
+
+        MSSQL_DATE = 100,
+        MSSQL_DATETIME = 101,
+
+        MSSQL_CHAR = 200,
+        MSSQL_VARCHAR = 201,
+        MSSQL_TEXT = 202,
+        MSSQL_NCHAR = 203,
+        MSSQL_NVARCHAR = 204,
+        MSSQL_NTEXT = 205,
+
+        MSSQL_BINARY = 300,
+        MSSQL_VARBINARY = 301,
+
+        MSSQL_UNIQUEIDENTIFIER = 400,
+
+
+        MySQL_INT = 1000,
+        MySQL_TINYINT = 1001,
+        MySQL_SMALLINT = 1002,
+        MySQL_BIGINT = 1003,
+        MySQL_DOUBLE = 1004,
+        MySQL_FLOAT = 1005,
+        MySQL_DECIMAL = 1006,
+
+        MySQL_DATE = 1100,
+        MySQL_DATETIME = 1101,
+        MySQL_TIMESTAMP = 1102,
+
+        MySQL_CHAR = 1200,
+        MySQL_VARCHAR = 1201,
+        MySQL_TEXT = 1202,
+
+        MySQL_BINARY = 1300,
+        MySQL_VARBINARY = 1301,
+        MySQL_BLOB = 1302,
+
+        MySQL_ENUM = 1400,
+
+
+        Postgres_INT4 = 2000,
+        Postgres_INT2 = 2001,
+        Postgres_INT8 = 2002,
+        Postgres_FLOAT8 = 2003,
+        Postgres_FLOAT4 = 2004,
+        Postgres_DECIMAL = 2005,
+
+        Postgres_DATE = 2100,
+        Postgres_TIMESTAMP = 2101,
+
+        Postgres_CHAR = 2200,
+        Postgres_VARCHAR = 2201,
+        Postgres_TEXT = 2202,
+
+        Postgres_BYTEA = 2300
+    }
+
+    public static class DataTypes
+    {
+        public static Type GetDotNetType(SqlDataType type)
+        {
+            switch (type)
+            {
+                case SqlDataType.MSSQL_INT:
+                case SqlDataType.MySQL_INT:
+                case SqlDataType.Postgres_INT4:
+                    return typeof(Int32);
+                case SqlDataType.MSSQL_BIGINT:
+                case SqlDataType.MySQL_BIGINT:
+                case SqlDataType.Postgres_INT8:
+                    return typeof(Int64);
+                case SqlDataType.MSSQL_SMALLINT:
+                case SqlDataType.MySQL_SMALLINT:
+                case SqlDataType.Postgres_INT2:
+                    return typeof(Int16);
+                case SqlDataType.MSSQL_TINYINT:
+                    return typeof(Byte);
+                case SqlDataType.MySQL_TINYINT:
+                    return typeof(SByte);
+                case SqlDataType.MSSQL_UNIQUEIDENTIFIER:
+                    return typeof(Guid);
+                case SqlDataType.MSSQL_DATETIME:
+                case SqlDataType.MySQL_DATETIME:
+                case SqlDataType.Postgres_TIMESTAMP:
+                    return typeof(DateTime);
+                case SqlDataType.MySQL_FLOAT:
+                case SqlDataType.Postgres_FLOAT4:
+                    return typeof(Single);
+                case SqlDataType.MSSQL_FLOAT:
+                case SqlDataType.MySQL_DOUBLE:
+                case SqlDataType.Postgres_FLOAT8:
+                    return typeof(Double);
+                case SqlDataType.MSSQL_DECIMAL:
+                case SqlDataType.MySQL_DECIMAL:
+                case SqlDataType.Postgres_DECIMAL:
+                    return typeof(Decimal);
+                case SqlDataType.MSSQL_CHAR:
+                case SqlDataType.MySQL_CHAR:
+                case SqlDataType.Postgres_CHAR:
+                case SqlDataType.MSSQL_NCHAR:
+                case SqlDataType.MSSQL_VARCHAR:
+                case SqlDataType.MySQL_VARCHAR:
+                case SqlDataType.Postgres_VARCHAR:
+                case SqlDataType.MSSQL_NVARCHAR:
+                case SqlDataType.MSSQL_TEXT:
+                case SqlDataType.MySQL_TEXT:
+                case SqlDataType.Postgres_TEXT:
+                case SqlDataType.MSSQL_NTEXT:
+                case SqlDataType.MySQL_TIMESTAMP:
+                case SqlDataType.MySQL_ENUM:
+                case SqlDataType.MSSQL_DATE:
+                case SqlDataType.MySQL_DATE:
+                case SqlDataType.Postgres_DATE:
+                    return typeof(String);
+                case SqlDataType.MSSQL_BINARY:
+                case SqlDataType.MSSQL_VARBINARY:
+                case SqlDataType.MySQL_BINARY:
+                case SqlDataType.MySQL_VARBINARY:
+                case SqlDataType.MySQL_BLOB:
+                case SqlDataType.Postgres_BYTEA:
+                    return typeof(Byte[]);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlDataType(Type type, TargetDatabase target)
+        {
+            if (type == typeof(byte[]))
+                return GetSqlVarBinaryDataType(target);
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Int32:
+                    return GetSqlIntDataType(target);
+                case TypeCode.Int16:
+                    return GetSqlSmallIntDataType(target);
+                case TypeCode.Int64:
+                    return GetSqlBigIntDataType(target);
+                case TypeCode.Single:
+                    return GetSqlFloatDataType(target);
+                case TypeCode.Double:
+                    return GetSqlDoubleDataType(target);
+                case TypeCode.Decimal:
+                    return GetSqlDecimalDataType(target);
+                case TypeCode.String:
+                    return GetSqlVarCharDataType(target);
+                case TypeCode.DateTime:
+                    return GetSqlDateTimeDataType(target);
+            }
+
+            throw new ArgumentOutOfRangeException();
+        }
+
+        public static SqlDataType GetSqlIntDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_INT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_INT;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_INT4;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlSmallIntDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_SMALLINT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_SMALLINT;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_INT2;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlBigIntDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_BIGINT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_BIGINT;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_INT8;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlFloatDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_FLOAT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_FLOAT;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_FLOAT4;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlDoubleDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_FLOAT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_DOUBLE;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_FLOAT8;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlDecimalDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_DECIMAL;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_DECIMAL;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_DECIMAL;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlBinaryDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_BINARY;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_BINARY;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_BYTEA;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlVarBinaryDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_VARBINARY;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_VARBINARY;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_BYTEA;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlVarCharDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_VARCHAR;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_VARCHAR;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_VARCHAR;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlTextDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_TEXT;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_TEXT;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_TEXT;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        public static SqlDataType GetSqlDateTimeDataType(TargetDatabase target)
+        {
+            switch (target)
+            {
+                case TargetDatabase.MS_SQL_Server:
+                    return SqlDataType.MSSQL_DATETIME;
+                case TargetDatabase.MySQL:
+                    return SqlDataType.MySQL_DATETIME;
+                case TargetDatabase.PostgreSQL:
+                case TargetDatabase.CockroachDB:
+                    return SqlDataType.Postgres_TIMESTAMP;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
@@ -532,7 +532,19 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) == (dynamic)right.Eval(r) ? !NOT : NOT;
+        public override object Eval(ResultRow r)
+        {
+            var leftEval = left.Eval(r);
+            var rightEval = right.Eval(r);
+
+            if (leftEval is String && rightEval is String)
+            {
+                return (String)leftEval == (String)rightEval ? !NOT : NOT;
+            }
+
+            // Assume data in DataRow are numeric
+            return (Convert.ToDecimal(leftEval) == Convert.ToDecimal(rightEval)) ? !NOT : NOT;
+        }
 
         public override List<ColumnRef> GetColumns()
         {
@@ -621,7 +633,14 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) > (dynamic)right.Eval(r) ? !NOT : NOT;
+        public override object Eval(ResultRow r)
+        {
+            var leftEval = left.Eval(r);
+            var rightEval = right.Eval(r);
+
+            // Assume data in DataRow are numeric
+            return Convert.ToDecimal(leftEval) > Convert.ToDecimal(rightEval) ? !NOT : NOT;
+        }
 
         public override List<ColumnRef> GetColumns()
         {
@@ -710,7 +729,14 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) < (dynamic)right.Eval(r) ? !NOT : NOT;
+        public override object Eval(ResultRow r)
+        {
+            var leftEval = left.Eval(r);
+            var rightEval = right.Eval(r);
+
+            // Assume data in DataRow are numeric
+            return Convert.ToDecimal(leftEval) < Convert.ToDecimal(rightEval) ? !NOT : NOT;
+        }
 
         public override List<ColumnRef> GetColumns()
         {

--- a/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
@@ -532,19 +532,7 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r)
-        {
-            var leftEval = left.Eval(r);
-            var rightEval = right.Eval(r);
-
-            if (leftEval is String && rightEval is String)
-            {
-                return (String)leftEval == (String)rightEval ? !NOT : NOT;
-            }
-
-            // Assume data in DataRow are numeric
-            return (Convert.ToDecimal(leftEval) == Convert.ToDecimal(rightEval)) ? !NOT : NOT;
-        }
+        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) == (dynamic)right.Eval(r) ? !NOT : NOT;
 
         public override List<ColumnRef> GetColumns()
         {
@@ -633,14 +621,7 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r)
-        {
-            var leftEval = left.Eval(r);
-            var rightEval = right.Eval(r);
-
-            // Assume data in DataRow are numeric
-            return Convert.ToDecimal(leftEval) > Convert.ToDecimal(rightEval) ? !NOT : NOT;
-        }
+        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) > (dynamic)right.Eval(r) ? !NOT : NOT;
 
         public override List<ColumnRef> GetColumns()
         {
@@ -729,14 +710,7 @@ namespace PrismaDB.QueryAST.DML
                       left.GetHashCode() *
                       right.GetHashCode());
 
-        public override object Eval(ResultRow r)
-        {
-            var leftEval = left.Eval(r);
-            var rightEval = right.Eval(r);
-
-            // Assume data in DataRow are numeric
-            return Convert.ToDecimal(leftEval) < Convert.ToDecimal(rightEval) ? !NOT : NOT;
-        }
+        public override object Eval(ResultRow r) => (dynamic)left.Eval(r) < (dynamic)right.Eval(r) ? !NOT : NOT;
 
         public override List<ColumnRef> GetColumns()
         {

--- a/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
@@ -326,6 +326,28 @@ namespace PrismaDB.QueryAST.DML
             _inValues.Add(child);
         }
 
+        public void SetChild(int index, Constant child)
+        {
+            child.Parent = this;
+            _inValues[index] = child;
+        }
+
+        public void InsertChild(int index, Constant child)
+        {
+            child.Parent = this;
+            _inValues.Insert(index, child);
+        }
+
+        public void RemoveChild(Constant child)
+        {
+            _inValues.Remove(child);
+        }
+
+        public void RemoveChildAt(int index)
+        {
+            _inValues.RemoveAt(index);
+        }
+
         public override bool UpdateChild(Expression child, Expression newChild)
         {
             for (var i = 0; i < InValues.Count; i++)

--- a/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/BooleanExpressions.cs
@@ -1,6 +1,7 @@
 using PrismaDB.QueryAST.Result;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace PrismaDB.QueryAST.DML
@@ -287,13 +288,14 @@ namespace PrismaDB.QueryAST.DML
     public class BooleanIn : BooleanExpression
     {
         public ColumnRef Column;
-        public List<Constant> InValues;
+        private List<Constant> _inValues;
+        public ReadOnlyCollection<Constant> InValues => _inValues.AsReadOnly();
 
         public BooleanIn()
         {
             Alias = new Identifier("");
             Column = new ColumnRef("");
-            InValues = new List<Constant>();
+            _inValues = new List<Constant>();
             NOT = false;
         }
 
@@ -301,9 +303,9 @@ namespace PrismaDB.QueryAST.DML
         {
             Alias = new Identifier("");
             Column = column.Clone() as ColumnRef;
-            InValues = new List<Constant>();
+            _inValues = new List<Constant>();
             foreach (var v in values)
-                InValues.Add(v.Clone() as Constant);
+                AddChild(v.Clone() as Constant);
             this.NOT = NOT;
         }
 
@@ -321,18 +323,18 @@ namespace PrismaDB.QueryAST.DML
         public void AddChild(Constant child)
         {
             child.Parent = this;
-            InValues.Add(child);
+            _inValues.Add(child);
         }
 
         public override bool UpdateChild(Expression child, Expression newChild)
         {
             for (var i = 0; i < InValues.Count; i++)
             {
-                if (InValues[i] == child)
+                if (_inValues[i] == child)
                 {
                     if (newChild is Constant cnst)
                     {
-                        InValues[i] = cnst;
+                        _inValues[i] = cnst;
                         cnst.Parent = this;
                         return true;
                     }
@@ -353,7 +355,7 @@ namespace PrismaDB.QueryAST.DML
             return NOT != otherBI.NOT
                 && Alias.Equals(otherBI.Alias)
                 && Column.Equals(otherBI.Column)
-                && InValues.All(x => otherBI.InValues.Exists(y => x.Equals(y)));
+                && InValues.SequenceEqual(otherBI.InValues);
         }
 
         public override int GetHashCode() =>

--- a/PrismaDB-QueryAST/DML/Expressions/Constants.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/Constants.cs
@@ -1,11 +1,50 @@
 ﻿using PrismaDB.QueryAST.Result;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace PrismaDB.QueryAST.DML
 {
-    public abstract class Constant : Expression { }
+    public abstract class Constant : Expression
+    {
+        public static Constant GetConstant(object value)
+        {
+            if (value == null)
+                return new NullConstant();
+
+            switch (value)
+            {
+                case int intValue:
+                    return new IntConstant(intValue);
+                case long longValue:
+                    return new IntConstant(longValue);
+                case short shortValue:
+                    return new IntConstant(shortValue);
+                case byte byteValue:
+                    return new IntConstant(byteValue);
+                case sbyte sbyteValue:
+                    return new IntConstant(sbyteValue);
+                case double doubleValue:
+                    return new FloatingPointConstant((decimal)doubleValue);
+                case float floatValue:
+                    return new FloatingPointConstant((decimal)floatValue);
+                case decimal decimalValue:
+                    return new FloatingPointConstant(decimalValue);
+                case byte[] byteaValue:
+                    return new BinaryConstant(byteaValue);
+                case DateTime datetimeValue:
+                    return new StringConstant(
+                        datetimeValue.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", CultureInfo.InvariantCulture));
+                case string stringValue:
+                    return new StringConstant(stringValue);
+                case DBNull _:
+                    return new NullConstant();
+                default:
+                    throw new NotSupportedException("Type not supported by GetConstant.");
+            }
+        }
+    }
 
     public class IntConstant : Constant
     {

--- a/PrismaDB-QueryAST/DML/Expressions/Constants.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/Constants.cs
@@ -26,11 +26,11 @@ namespace PrismaDB.QueryAST.DML
                 case sbyte sbyteValue:
                     return new IntConstant(sbyteValue);
                 case double doubleValue:
-                    return new FloatingPointConstant((decimal)doubleValue);
+                    return new DecimalConstant((decimal)doubleValue);
                 case float floatValue:
-                    return new FloatingPointConstant((decimal)floatValue);
+                    return new DecimalConstant((decimal)floatValue);
                 case decimal decimalValue:
-                    return new FloatingPointConstant(decimalValue);
+                    return new DecimalConstant(decimalValue);
                 case byte[] byteaValue:
                     return new BinaryConstant(byteaValue);
                 case DateTime datetimeValue:
@@ -157,21 +157,21 @@ namespace PrismaDB.QueryAST.DML
                       binvalue.Aggregate(1, unchecked((x, y) => x * y.GetHashCode())));
     }
 
-    public class FloatingPointConstant : Constant
+    public class DecimalConstant : Constant
     {
-        public Decimal floatvalue;
+        public Decimal decimalvalue;
 
-        public FloatingPointConstant() : this(0) { }
+        public DecimalConstant() : this(0) { }
 
-        public FloatingPointConstant(Decimal value, string aliasName = "")
+        public DecimalConstant(Decimal value, string aliasName = "")
         {
-            floatvalue = value;
+            decimalvalue = value;
             Alias = new Identifier(aliasName);
         }
 
-        public override object Clone() => new FloatingPointConstant(floatvalue, Alias.id);
+        public override object Clone() => new DecimalConstant(decimalvalue, Alias.id);
 
-        public override object Eval(ResultRow r) => floatvalue;
+        public override object Eval(ResultRow r) => decimalvalue;
 
         public override List<ColumnRef> GetColumns() => new List<ColumnRef>();
 
@@ -179,19 +179,19 @@ namespace PrismaDB.QueryAST.DML
 
         public override bool UpdateChild(Expression child, Expression newChild) => false;
 
-        public override string ToString() => DialectResolver.Dialect.FloatingPointConstantToString(this);
+        public override string ToString() => DialectResolver.Dialect.DecimalConstantToString(this);
 
         public override bool Equals(object other)
         {
-            if (!(other is FloatingPointConstant otherIC)) return false;
+            if (!(other is DecimalConstant otherIC)) return false;
 
             return Alias.Equals(otherIC.Alias)
-                && floatvalue == otherIC.floatvalue;
+                && decimalvalue == otherIC.decimalvalue;
         }
 
         public override int GetHashCode() =>
             unchecked(Alias.GetHashCode() *
-                      floatvalue.GetHashCode());
+                      decimalvalue.GetHashCode());
     }
 
     public class NullConstant : Constant

--- a/PrismaDB-QueryAST/DML/Expressions/Operations.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/Operations.cs
@@ -1,4 +1,6 @@
-﻿using PrismaDB.QueryAST.Result;
+﻿using Microsoft.CSharp.RuntimeBinder;
+using PrismaDB.QueryAST.Result;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -65,7 +67,11 @@ namespace PrismaDB.QueryAST.DML
             return clone;
         }
 
-        public override object Eval(ResultRow r) => (int)left.Eval(r) + (int)right.Eval(r);
+        public override object Eval(ResultRow r)
+        {
+            try { return (dynamic)left.Eval(r) + (dynamic)right.Eval(r); }
+            catch (RuntimeBinderException) { return Convert.ToDecimal(left.Eval(r)) + Convert.ToDecimal(right.Eval(r)); }
+        }
 
         public override List<ColumnRef> GetColumns()
         {
@@ -119,7 +125,11 @@ namespace PrismaDB.QueryAST.DML
             return clone;
         }
 
-        public override object Eval(ResultRow r) => (int)left.Eval(r) - (int)right.Eval(r);
+        public override object Eval(ResultRow r)
+        {
+            try { return (dynamic)left.Eval(r) - (dynamic)right.Eval(r); }
+            catch (RuntimeBinderException) { return Convert.ToDecimal(left.Eval(r)) - Convert.ToDecimal(right.Eval(r)); }
+        }
 
         public override List<ColumnRef> GetColumns()
         {
@@ -173,7 +183,11 @@ namespace PrismaDB.QueryAST.DML
             return clone;
         }
 
-        public override object Eval(ResultRow r) => (int)left.Eval(r) * (int)right.Eval(r);
+        public override object Eval(ResultRow r)
+        {
+            try { return (dynamic)left.Eval(r) * (dynamic)right.Eval(r); }
+            catch (RuntimeBinderException) { return Convert.ToDecimal(left.Eval(r)) * Convert.ToDecimal(right.Eval(r)); }
+        }
 
         public override List<ColumnRef> GetColumns()
         {
@@ -227,7 +241,11 @@ namespace PrismaDB.QueryAST.DML
             return clone;
         }
 
-        public override object Eval(ResultRow r) => (int)left.Eval(r) / (int)right.Eval(r);
+        public override object Eval(ResultRow r)
+        {
+            try { return (dynamic)left.Eval(r) / (dynamic)right.Eval(r); }
+            catch (RuntimeBinderException) { return Convert.ToDecimal(left.Eval(r)) / Convert.ToDecimal(right.Eval(r)); }
+        }
 
         public override List<ColumnRef> GetColumns()
         {

--- a/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace PrismaDB.QueryAST.DML
@@ -103,7 +104,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ScalarFunctionToString(this);
     }
 
-#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class PaillierAdditionFunction : ScalarFunction
     {
         public PaillierAdditionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -142,6 +143,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.PaillierAdditionFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class PaillierSubtractionFunction : ScalarFunction
     {
         public PaillierSubtractionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -180,6 +182,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.PaillierSubtractionFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class ElGamalMultiplicationFunction : ScalarFunction
     {
         public ElGamalMultiplicationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -218,6 +221,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ElGamalMultiplicationFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class ElGamalDivisionFunction : ScalarFunction
     {
         public ElGamalDivisionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -256,6 +260,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ElGamalDivisionFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class SumAggregationFunction : ScalarFunction
     {
         public SumAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -278,6 +283,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.SumAggregationFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class CountAggregationFunction : ScalarFunction
     {
         public CountAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -300,6 +306,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.CountAggregationFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class AvgAggregationFunction : ScalarFunction
     {
         public AvgAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -322,6 +329,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.AvgAggregationFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class StDevAggregationFunction : ScalarFunction
     {
         public StDevAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -344,6 +352,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.StDevAggregationFunctionToString(this);
     }
 
+    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class PaillierAggregationSumFunction : ScalarFunction
     {
         public PaillierAggregationSumFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -365,5 +374,4 @@ namespace PrismaDB.QueryAST.DML
 
         public override string ToString() => DialectResolver.Dialect.PaillierAggregationSumFunctionToString(this);
     }
-#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
 }

--- a/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace PrismaDB.QueryAST.DML
@@ -104,7 +103,7 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ScalarFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class PaillierAdditionFunction : ScalarFunction
     {
         public PaillierAdditionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -143,7 +142,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.PaillierAdditionFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class PaillierSubtractionFunction : ScalarFunction
     {
         public PaillierSubtractionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -182,7 +180,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.PaillierSubtractionFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class ElGamalMultiplicationFunction : ScalarFunction
     {
         public ElGamalMultiplicationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -221,7 +218,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ElGamalMultiplicationFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class ElGamalDivisionFunction : ScalarFunction
     {
         public ElGamalDivisionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -260,7 +256,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.ElGamalDivisionFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class SumAggregationFunction : ScalarFunction
     {
         public SumAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -283,7 +278,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.SumAggregationFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class CountAggregationFunction : ScalarFunction
     {
         public CountAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -306,7 +300,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.CountAggregationFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class AvgAggregationFunction : ScalarFunction
     {
         public AvgAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -329,7 +322,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.AvgAggregationFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class StDevAggregationFunction : ScalarFunction
     {
         public StDevAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -352,7 +344,6 @@ namespace PrismaDB.QueryAST.DML
         public override string ToString() => DialectResolver.Dialect.StDevAggregationFunctionToString(this);
     }
 
-    [SuppressMessage("", "CS0659: Type overrides Object.Equals(object o) but does not override Object.GetHashCode()")]
     public class PaillierAggregationSumFunction : ScalarFunction
     {
         public PaillierAggregationSumFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
@@ -374,4 +365,5 @@ namespace PrismaDB.QueryAST.DML
 
         public override string ToString() => DialectResolver.Dialect.PaillierAggregationSumFunctionToString(this);
     }
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
 }

--- a/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
@@ -1,6 +1,7 @@
 ﻿using PrismaDB.QueryAST.Result;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace PrismaDB.QueryAST.DML
@@ -8,30 +9,29 @@ namespace PrismaDB.QueryAST.DML
     public class ScalarFunction : Expression
     {
         public Identifier FunctionName;
-        public List<Expression> Parameters;
+        protected List<Expression> _parameters;
+        public ReadOnlyCollection<Expression> Parameters => _parameters.AsReadOnly();
 
         public ScalarFunction()
         {
             FunctionName = new Identifier("");
             Alias = new Identifier("");
-            Parameters = new List<Expression>();
+            _parameters = new List<Expression>();
         }
 
-        public ScalarFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public ScalarFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
         {
             FunctionName = new Identifier(functionName);
             Alias = new Identifier(aliasName);
-            Parameters = new List<Expression>();
+            _parameters = new List<Expression>();
             if (parameters != null)
+            {
                 foreach (var v in parameters)
-                {
-                    var newp = v.Clone() as Expression;
-                    newp.Parent = this;
-                    Parameters.Add(newp as Expression);
-                }
+                    AddChild(v.Clone() as Expression);
+            }
         }
 
-        public ScalarFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public ScalarFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : this(functionName.id, alias?.id ?? "", parameters) { }
 
         public override object Clone() => new ScalarFunction(FunctionName, Alias, Parameters);
@@ -56,9 +56,9 @@ namespace PrismaDB.QueryAST.DML
         {
             for (var i = 0; i < Parameters.Count; i++)
             {
-                if (Parameters[i] == child) // ReSharper disable once PossibleUnintendedReferenceComparison
+                if (_parameters[i] == child) // ReSharper disable once PossibleUnintendedReferenceComparison
                 {
-                    Parameters[i] = newChild;
+                    _parameters[i] = newChild;
                     newChild.Parent = this;
                     return true;
                 }
@@ -70,39 +70,46 @@ namespace PrismaDB.QueryAST.DML
         public void AddChild(Expression child)
         {
             child.Parent = this;
-            Parameters.Add(child);
+            _parameters.Add(child);
+        }
+
+        public void AddChild(int index, Expression child)
+        {
+            child.Parent = this;
+            _parameters[index] = child;
         }
 
         public override int GetHashCode() =>
             unchecked(FunctionName.GetHashCode() *
                       Alias.GetHashCode() *
-                      Parameters.Select(x => x.GetHashCode()).Aggregate((a, b) => a * b));
+                      _parameters.Select(x => x.GetHashCode()).Aggregate((a, b) => a * b));
 
         public override string ToString() => DialectResolver.Dialect.ScalarFunctionToString(this);
     }
 
+#pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class PaillierAdditionFunction : ScalarFunction
     {
-        public PaillierAdditionFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public PaillierAdditionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public PaillierAdditionFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public PaillierAdditionFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public PaillierAdditionFunction(string functionName, Expression left, Expression right, Expression N)
             : this(functionName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(N);
+            AddChild(left);
+            AddChild(right);
+            AddChild(N);
         }
 
         public PaillierAdditionFunction(string functionName, Expression left, Expression right, Expression N, string aliasName)
             : this(functionName, aliasName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(N);
+            AddChild(left);
+            AddChild(right);
+            AddChild(N);
         }
 
         public override object Clone() => new PaillierAdditionFunction(FunctionName, Alias, Parameters);
@@ -121,26 +128,26 @@ namespace PrismaDB.QueryAST.DML
 
     public class PaillierSubtractionFunction : ScalarFunction
     {
-        public PaillierSubtractionFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public PaillierSubtractionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public PaillierSubtractionFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public PaillierSubtractionFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public PaillierSubtractionFunction(string functionName, Expression left, Expression right, Expression N)
             : this(functionName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(N);
+            AddChild(left);
+            AddChild(right);
+            AddChild(N);
         }
 
         public PaillierSubtractionFunction(string functionName, Expression left, Expression right, Expression N, string aliasName)
             : this(functionName, aliasName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(N);
+            AddChild(left);
+            AddChild(right);
+            AddChild(N);
         }
 
         public override object Clone() => new PaillierSubtractionFunction(FunctionName, Alias, Parameters);
@@ -159,26 +166,26 @@ namespace PrismaDB.QueryAST.DML
 
     public class ElGamalMultiplicationFunction : ScalarFunction
     {
-        public ElGamalMultiplicationFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public ElGamalMultiplicationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public ElGamalMultiplicationFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public ElGamalMultiplicationFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public ElGamalMultiplicationFunction(string functionName, Expression left, Expression right, Expression P)
             : this(functionName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(P);
+            AddChild(left);
+            AddChild(right);
+            AddChild(P);
         }
 
         public ElGamalMultiplicationFunction(string functionName, Expression left, Expression right, Expression P, string aliasName)
             : this(functionName, aliasName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(P);
+            AddChild(left);
+            AddChild(right);
+            AddChild(P);
         }
 
         public override object Clone() => new ElGamalMultiplicationFunction(FunctionName, Alias, Parameters);
@@ -197,26 +204,26 @@ namespace PrismaDB.QueryAST.DML
 
     public class ElGamalDivisionFunction : ScalarFunction
     {
-        public ElGamalDivisionFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public ElGamalDivisionFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public ElGamalDivisionFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public ElGamalDivisionFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public ElGamalDivisionFunction(string functionName, Expression left, Expression right, Expression P)
             : this(functionName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(P);
+            AddChild(left);
+            AddChild(right);
+            AddChild(P);
         }
 
         public ElGamalDivisionFunction(string functionName, Expression left, Expression right, Expression P, string aliasName)
             : this(functionName, aliasName)
         {
-            Parameters.Add(left);
-            Parameters.Add(right);
-            Parameters.Add(P);
+            AddChild(left);
+            AddChild(right);
+            AddChild(P);
         }
 
         public override object Clone() => new ElGamalDivisionFunction(FunctionName, Alias, Parameters);
@@ -235,10 +242,10 @@ namespace PrismaDB.QueryAST.DML
 
     public class SumAggregationFunction : ScalarFunction
     {
-        public SumAggregationFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public SumAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public SumAggregationFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public SumAggregationFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public override object Clone() => new SumAggregationFunction(FunctionName, Alias, Parameters);
@@ -257,10 +264,10 @@ namespace PrismaDB.QueryAST.DML
 
     public class CountAggregationFunction : ScalarFunction
     {
-        public CountAggregationFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public CountAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public CountAggregationFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public CountAggregationFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public override object Clone() => new CountAggregationFunction(FunctionName, Alias, Parameters);
@@ -279,10 +286,10 @@ namespace PrismaDB.QueryAST.DML
 
     public class AvgAggregationFunction : ScalarFunction
     {
-        public AvgAggregationFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public AvgAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public AvgAggregationFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public AvgAggregationFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public override object Clone() => new AvgAggregationFunction(FunctionName, Alias, Parameters);
@@ -301,10 +308,10 @@ namespace PrismaDB.QueryAST.DML
 
     public class StDevAggregationFunction : ScalarFunction
     {
-        public StDevAggregationFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public StDevAggregationFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public StDevAggregationFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public StDevAggregationFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public override object Clone() => new StDevAggregationFunction(FunctionName, Alias, Parameters);
@@ -323,10 +330,10 @@ namespace PrismaDB.QueryAST.DML
 
     public class PaillierAggregationSumFunction : ScalarFunction
     {
-        public PaillierAggregationSumFunction(string functionName = "", string aliasName = "", List<Expression> parameters = null)
+        public PaillierAggregationSumFunction(string functionName = "", string aliasName = "", ICollection<Expression> parameters = null)
             : base(functionName, aliasName, parameters) { }
 
-        public PaillierAggregationSumFunction(Identifier functionName, Identifier alias = null, List<Expression> parameters = null)
+        public PaillierAggregationSumFunction(Identifier functionName, Identifier alias = null, ICollection<Expression> parameters = null)
             : base(functionName, alias, parameters) { }
 
         public override object Clone() => new PaillierAggregationSumFunction(FunctionName, Alias, Parameters);
@@ -342,4 +349,5 @@ namespace PrismaDB.QueryAST.DML
 
         public override string ToString() => DialectResolver.Dialect.PaillierAggregationSumFunctionToString(this);
     }
+#pragma warning restore CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
 }

--- a/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
+++ b/PrismaDB-QueryAST/DML/Expressions/ScalarFunction.cs
@@ -73,10 +73,26 @@ namespace PrismaDB.QueryAST.DML
             _parameters.Add(child);
         }
 
-        public void AddChild(int index, Expression child)
+        public void SetChild(int index, Expression child)
         {
             child.Parent = this;
             _parameters[index] = child;
+        }
+
+        public void InsertChild(int index, Expression child)
+        {
+            child.Parent = this;
+            _parameters.Insert(index, child);
+        }
+
+        public void RemoveChild(Expression child)
+        {
+            _parameters.Remove(child);
+        }
+
+        public void RemoveChildAt(int index)
+        {
+            _parameters.RemoveAt(index);
         }
 
         public override int GetHashCode() =>

--- a/PrismaDB-QueryAST/Dialect/IDialect.cs
+++ b/PrismaDB-QueryAST/Dialect/IDialect.cs
@@ -25,7 +25,7 @@ namespace PrismaDB.QueryAST
         string IntConstantToString(IntConstant q);
         string BinaryConstantToString(BinaryConstant q);
         string StringConstantToString(StringConstant q);
-        string FloatingPointConstantToString(FloatingPointConstant q);
+        string DecimalConstantToString(DecimalConstant q);
         string AdditionToString(Addition q);
         string SubtractionToString(Subtraction q);
         string MultiplicationToString(Multiplication q);

--- a/PrismaDB-QueryAST/PrismaDB-QueryAST.csproj
+++ b/PrismaDB-QueryAST/PrismaDB-QueryAST.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>PrismaDB.QueryAST</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="PrismaDB-Commons" Version="0.2.0.10" />
     <PackageReference Include="PrismaDB-Result" Version="0.2.0.36" />
   </ItemGroup>

--- a/PrismaDB-QueryAST/Result/ResultColumnHeader.cs
+++ b/PrismaDB-QueryAST/Result/ResultColumnHeader.cs
@@ -34,74 +34,7 @@ namespace PrismaDB.QueryAST.Result
             set
             {
                 _columnDefinition = value;
-
-                switch (_columnDefinition.DataType)
-                {
-                    case SqlDataType.MSSQL_INT:
-                    case SqlDataType.MySQL_INT:
-                    case SqlDataType.Postgres_INT4:
-                        DataType = typeof(Int32);
-                        break;
-                    case SqlDataType.MSSQL_BIGINT:
-                    case SqlDataType.MySQL_BIGINT:
-                    case SqlDataType.Postgres_INT8:
-                        DataType = typeof(Int64);
-                        break;
-                    case SqlDataType.MSSQL_SMALLINT:
-                    case SqlDataType.MySQL_SMALLINT:
-                    case SqlDataType.Postgres_INT2:
-                        DataType = typeof(Int16);
-                        break;
-                    case SqlDataType.MSSQL_TINYINT:
-                        DataType = typeof(Byte);
-                        break;
-                    case SqlDataType.MySQL_TINYINT:
-                        DataType = typeof(SByte);
-                        break;
-                    case SqlDataType.MSSQL_UNIQUEIDENTIFIER:
-                        DataType = typeof(Guid);
-                        break;
-                    case SqlDataType.MSSQL_DATETIME:
-                    case SqlDataType.MySQL_DATETIME:
-                    case SqlDataType.Postgres_TIMESTAMP:
-                        DataType = typeof(DateTime);
-                        break;
-                    case SqlDataType.MSSQL_FLOAT:
-                    case SqlDataType.MySQL_DOUBLE:
-                    case SqlDataType.Postgres_FLOAT4:
-                    case SqlDataType.Postgres_FLOAT8:
-                        DataType = typeof(Double);
-                        break;
-                    case SqlDataType.MSSQL_CHAR:
-                    case SqlDataType.MySQL_CHAR:
-                    case SqlDataType.Postgres_CHAR:
-                    case SqlDataType.MSSQL_NCHAR:
-                    case SqlDataType.MSSQL_VARCHAR:
-                    case SqlDataType.MySQL_VARCHAR:
-                    case SqlDataType.Postgres_VARCHAR:
-                    case SqlDataType.MSSQL_NVARCHAR:
-                    case SqlDataType.MSSQL_TEXT:
-                    case SqlDataType.MySQL_TEXT:
-                    case SqlDataType.Postgres_TEXT:
-                    case SqlDataType.MSSQL_NTEXT:
-                    case SqlDataType.MySQL_TIMESTAMP:
-                    case SqlDataType.MySQL_ENUM:
-                    case SqlDataType.MSSQL_DATE:
-                    case SqlDataType.MySQL_DATE:
-                    case SqlDataType.Postgres_DATE:
-                        DataType = typeof(String);
-                        break;
-                    case SqlDataType.MSSQL_BINARY:
-                    case SqlDataType.MSSQL_VARBINARY:
-                    case SqlDataType.MySQL_BINARY:
-                    case SqlDataType.MySQL_VARBINARY:
-                    case SqlDataType.MySQL_BLOB:
-                    case SqlDataType.Postgres_BYTEA:
-                        DataType = typeof(byte[]);
-                        break;
-                    default:
-                        throw new NotSupportedException("DataType not supported in DataTable.");
-                }
+                DataType = DataTypes.GetDotNetType(_columnDefinition.DataType);
             }
         }
 

--- a/PrismaDB-QueryAST/Result/ResultColumnHeader.cs
+++ b/PrismaDB-QueryAST/Result/ResultColumnHeader.cs
@@ -1,18 +1,17 @@
-﻿using Newtonsoft.Json;
-using PrismaDB.QueryAST.DDL;
+﻿using PrismaDB.QueryAST.DDL;
 using PrismaDB.QueryAST.DML;
 using System;
-using System.Xml.Serialization;
+using System.Runtime.Serialization;
 
 namespace PrismaDB.QueryAST.Result
 {
+    [DataContract]
     public class ResultColumnHeader : PrismaDB.Result.ResultColumnHeader
     {
         private Expression _expression;
         private ColumnDefinition _columnDefinition;
 
-        [JsonIgnore]
-        [XmlIgnore]
+        [IgnoreDataMember]
         public Expression Expression
         {
             get => _expression;
@@ -27,8 +26,7 @@ namespace PrismaDB.QueryAST.Result
             }
         }
 
-        [JsonIgnore]
-        [XmlIgnore]
+        [IgnoreDataMember]
         public ColumnDefinition ColumnDefinition
         {
             get => _columnDefinition;

--- a/PrismaDB-QueryAST/TargetDatabase.cs
+++ b/PrismaDB-QueryAST/TargetDatabase.cs
@@ -1,0 +1,10 @@
+﻿namespace PrismaDB.QueryAST
+{
+    public enum TargetDatabase
+    {
+        MS_SQL_Server,
+        MySQL,
+        PostgreSQL,
+        CockroachDB
+    }
+}

--- a/QueryTests/QueryTest.cs
+++ b/QueryTests/QueryTest.cs
@@ -263,6 +263,67 @@ namespace QueryTests
             }
         }
 
+        [Fact(DisplayName = "Operations")]
+        public void TestOperations()
+        {
+            //Initialize
+            var table = new ResultTable();
+            table.Columns.Add(new ColumnRef("a"));
+            table.Columns.Add(new ColumnRef("b"));
+            table.Columns.Add(new ColumnRef("c"));
+            table.Columns.Add(new ColumnRef("d"));
+            var row = table.NewRow();
+            row.Add(new object[] { 1, 432, 24.42d, 0.256m });
+
+            var computeAddInt = new Addition(new ColumnRef("a"), new ColumnRef("b"));
+            Assert.Equal(433, computeAddInt.Eval(row));
+
+            var computeAddDouble = new Addition(new ColumnRef("c"), new ColumnRef("c"));
+            Assert.Equal(48.84, computeAddDouble.Eval(row));
+
+            var computeAddDecimal = new Addition(new ColumnRef("d"), new ColumnRef("d"));
+            Assert.Equal(0.512m, computeAddDecimal.Eval(row));
+
+            var computeAddMixed = new Addition(new ColumnRef("c"), new ColumnRef("d"));
+            Assert.Equal(24.676m, computeAddMixed.Eval(row));
+
+            var computeSubInt = new Subtraction(new ColumnRef("a"), new ColumnRef("b"));
+            Assert.Equal(-431, computeSubInt.Eval(row));
+
+            var computeSubDouble = new Subtraction(new ColumnRef("c"), new ColumnRef("c"));
+            Assert.Equal(0d, computeSubDouble.Eval(row));
+
+            var computeSubDecimal = new Subtraction(new ColumnRef("d"), new ColumnRef("d"));
+            Assert.Equal(0m, computeSubDecimal.Eval(row));
+
+            var computeSubMixed = new Subtraction(new ColumnRef("c"), new ColumnRef("d"));
+            Assert.Equal(24.164m, computeSubMixed.Eval(row));
+
+            var computeMulInt = new Multiplication(new ColumnRef("a"), new ColumnRef("b"));
+            Assert.Equal(432, computeMulInt.Eval(row));
+
+            var computeMulDouble = new Multiplication(new ColumnRef("c"), new ColumnRef("c"));
+            Assert.Equal(24.42d * 24.42d, computeMulDouble.Eval(row));
+
+            var computeMulDecimal = new Multiplication(new ColumnRef("d"), new ColumnRef("d"));
+            Assert.Equal(0.065536m, computeMulDecimal.Eval(row));
+
+            var computeMulMixed = new Multiplication(new ColumnRef("c"), new ColumnRef("d"));
+            Assert.Equal(6.25152m, computeMulMixed.Eval(row));
+
+            var computeDivInt = new Division(new ColumnRef("a"), new ColumnRef("b"));
+            Assert.Equal(0, computeDivInt.Eval(row));
+
+            var computeDivDouble = new Division(new ColumnRef("c"), new ColumnRef("c"));
+            Assert.Equal(24.42d / 24.42d, computeDivDouble.Eval(row));
+
+            var computeDivDecimal = new Division(new ColumnRef("d"), new ColumnRef("d"));
+            Assert.Equal(1m, computeDivDecimal.Eval(row));
+
+            var computeDivMixed = new Division(new ColumnRef("c"), new ColumnRef("d"));
+            Assert.Equal(95.390625m, computeDivMixed.Eval(row));
+        }
+
         [Fact(DisplayName = "ResultTable Serialization")]
         public void TestResultTableSerialization()
         {

--- a/QueryTests/QueryTest.cs
+++ b/QueryTests/QueryTest.cs
@@ -18,21 +18,21 @@ namespace QueryTests
         public void FunctionEquals()
         {
             var func1 = new ScalarFunction("func");
-            func1.Parameters.Add(new IntConstant(1));
-            func1.Parameters.Add(new StringConstant("abc"));
+            func1.AddChild(new IntConstant(1));
+            func1.AddChild(new StringConstant("abc"));
 
             var func2 = new ScalarFunction("func");
-            func2.Parameters.Add(new IntConstant(1));
-            func2.Parameters.Add(new StringConstant("abc"));
+            func2.AddChild(new IntConstant(1));
+            func2.AddChild(new StringConstant("abc"));
             Assert.Equal(func1, func2);
 
             var func3 = new ScalarFunction("func");
-            func3.Parameters.Add(new StringConstant("abc"));
-            func3.Parameters.Add(new IntConstant(1));
+            func3.AddChild(new StringConstant("abc"));
+            func3.AddChild(new IntConstant(1));
             Assert.NotEqual(func1, func3);
 
             var func4 = (ScalarFunction)func2.Clone();
-            func4.Parameters[0] = new StringConstant("123");
+            func4.AddChild(0, new StringConstant("123"));
 
             Assert.NotEqual(func2, func4);
 
@@ -40,11 +40,11 @@ namespace QueryTests
             Assert.NotEqual(func1, func5);
 
             var func6 = new ScalarFunction("func");
-            func6.Parameters.Add(new IntConstant(1));
+            func6.AddChild(new IntConstant(1));
             Assert.NotEqual(func1, func6);
 
             var func7 = new ScalarFunction("func");
-            func7.Parameters.Add(new ColumnRef("tt", "col"));
+            func7.AddChild(new ColumnRef("tt", "col"));
             Assert.Single(func7.GetColumns());
             Assert.Equal(new ColumnRef("tt", "col"), func7.GetColumns()[0]);
         }
@@ -54,11 +54,11 @@ namespace QueryTests
         {
             {
                 var func = new SumAggregationFunction("fn");
-                func.Parameters.Add(new ColumnRef("a"));
+                func.AddChild(new ColumnRef("a"));
 
                 var func2 = new SumAggregationFunction("fn");
                 Assert.NotEqual(func, func2);
-                func2.Parameters.Add(new ColumnRef("a"));
+                func2.AddChild(new ColumnRef("a"));
                 Assert.Equal(func, func2);
 
                 var func3 = func.Clone() as SumAggregationFunction;
@@ -66,11 +66,11 @@ namespace QueryTests
             }
             {
                 var func = new CountAggregationFunction("fn");
-                func.Parameters.Add(new ColumnRef("a"));
+                func.AddChild(new ColumnRef("a"));
 
                 var func2 = new CountAggregationFunction("fn");
                 Assert.NotEqual(func, func2);
-                func2.Parameters.Add(new ColumnRef("a"));
+                func2.AddChild(new ColumnRef("a"));
                 Assert.Equal(func, func2);
 
                 var func3 = func.Clone() as CountAggregationFunction;
@@ -78,11 +78,11 @@ namespace QueryTests
             }
             {
                 var func = new AvgAggregationFunction("fn");
-                func.Parameters.Add(new ColumnRef("a"));
+                func.AddChild(new ColumnRef("a"));
 
                 var func2 = new AvgAggregationFunction("fn");
                 Assert.NotEqual(func, func2);
-                func2.Parameters.Add(new ColumnRef("a"));
+                func2.AddChild(new ColumnRef("a"));
                 Assert.Equal(func, func2);
 
                 var func3 = func.Clone() as AvgAggregationFunction;

--- a/QueryTests/QueryTest.cs
+++ b/QueryTests/QueryTest.cs
@@ -32,7 +32,7 @@ namespace QueryTests
             Assert.NotEqual(func1, func3);
 
             var func4 = (ScalarFunction)func2.Clone();
-            func4.AddChild(0, new StringConstant("123"));
+            func4.SetChild(0, new StringConstant("123"));
 
             Assert.NotEqual(func2, func4);
 

--- a/QueryTests/QueryTest.cs
+++ b/QueryTests/QueryTest.cs
@@ -266,7 +266,6 @@ namespace QueryTests
         [Fact(DisplayName = "Operations")]
         public void TestOperations()
         {
-            //Initialize
             var table = new ResultTable();
             table.Columns.Add(new ColumnRef("a"));
             table.Columns.Add(new ColumnRef("b"));


### PR DESCRIPTION
- Eval for operations support all datatypes (using dynamic), resolves https://github.com/bazzilic/PrismaDB-INTERNAL-DEV/issues/86
- Expression children collection robustness (Public member is read-only, forces devs to use AddChild())
- GetConstant() for getting a Constant obj from a primitive datatype